### PR TITLE
scripting: enqueue called functions in the function queue after a yield

### DIFF
--- a/rtt/base/ExecutableInterface.hpp
+++ b/rtt/base/ExecutableInterface.hpp
@@ -67,7 +67,12 @@ namespace RTT
              * is called next.
              * @param ee The pointer to the engine calling us.
              */
-            void loaded(ExecutionEngine* ee) { engine = ee; this->loading();}
+            void loaded(ExecutionEngine* ee) {
+                if (!engine) {
+                    engine = ee;
+                    this->loading();
+                }
+            }
 
             /**
              * Called by the ExecutionEngine \a ee to tell
@@ -75,7 +80,12 @@ namespace RTT
              * user's loading() function
              * is called first and the engine pointer is cleared next.
              */
-            void unloaded() { this->unloading(); engine = 0;}
+            void unloaded() {
+                if (engine) {
+                    this->unloading();
+                    engine = 0;
+                }
+            }
 
             ExecutableInterface() : engine(0) {}
             virtual ~ExecutableInterface() {}

--- a/tests/scripting_test.cpp
+++ b/tests/scripting_test.cpp
@@ -45,11 +45,6 @@ BOOST_AUTO_TEST_CASE(TestGetProvider)
 
     PluginLoader::Instance()->loadService("scripting",tc);
 
-    // We use a sequential activity in order to force execution on trigger().
-//    tc->stop();
-//    BOOST_CHECK( tc->setActivity( new SequentialActivity() ) );
-//    tc->start();
-
     boost::shared_ptr<Scripting> sc = tc->getProvider<Scripting>("scripting");
     BOOST_REQUIRE( sc );
     BOOST_CHECK ( sc->ready() );
@@ -76,11 +71,6 @@ BOOST_AUTO_TEST_CASE(TestGetProvider)
 BOOST_AUTO_TEST_CASE(TestScriptingParser)
 {
     PluginLoader::Instance()->loadService("scripting",tc);
-
-    // We use a sequential activity in order to force execution on trigger().
-//    tc->stop();
-//    BOOST_CHECK( tc->setActivity( new SequentialActivity() ) );
-//    tc->start();
 
     boost::shared_ptr<Scripting> sc = tc->getProvider<Scripting>("scripting");
     BOOST_REQUIRE( sc );
@@ -162,11 +152,6 @@ BOOST_AUTO_TEST_CASE(TestScriptingFunction)
 {
     PluginLoader::Instance()->loadService("scripting",tc);
 
-    // We use a sequential activity in order to force execution on trigger().
-//    tc->stop();
-//    BOOST_CHECK( tc->setActivity( new SequentialActivity() ) );
-//    tc->start();
-
     boost::shared_ptr<Scripting> sc = tc->getProvider<Scripting>("scripting");
     BOOST_REQUIRE( sc );
     BOOST_CHECK ( sc->ready() );
@@ -176,7 +161,7 @@ BOOST_AUTO_TEST_CASE(TestScriptingFunction)
     i = 0;
 
     // define a function (added to scripting interface):
-    string statements="void func1(void) { test.printNumber(\"[ENTER func1()] CycleCounter = \", CycleCounter); test.increase(); test.printNumber(\"[EXIT func1()] CycleCounter = \", CycleCounter); }\n";
+    string statements="void func1(void) { test.increase(); }\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
     BOOST_CHECK_EQUAL( i, 0);
@@ -204,7 +189,7 @@ BOOST_AUTO_TEST_CASE(TestScriptingFunction)
     BOOST_CHECK( GlobalService::Instance()->provides()->hasMember("gfunc1"));
 
     // nested function call:
-    statements="void func2(void) { test.printNumber(\"[ENTER func2()] CycleCounter = \", CycleCounter); func1(); test.printNumber(\"[EXIT func2()] CycleCounter = \", CycleCounter); }\n";
+    statements="void func2(void) { func1(); }\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
     BOOST_CHECK_EQUAL( i, 0);
@@ -336,11 +321,6 @@ BOOST_AUTO_TEST_CASE(TestScriptingFunctionWithYield)
     // will be executed again while we are waiting.
     tc->setPeriod(0.1);
 
-//    // We use a sequential activity in order to force execution on trigger().
-//    tc->stop();
-//    BOOST_CHECK( tc->setActivity( new SequentialActivity() ) );
-//    tc->start();
-
     boost::shared_ptr<Scripting> sc = tc->getProvider<Scripting>("scripting");
     BOOST_REQUIRE( sc );
     BOOST_CHECK ( sc->ready() );
@@ -356,8 +336,8 @@ BOOST_AUTO_TEST_CASE(TestScriptingFunctionWithYield)
     BOOST_CHECK_EQUAL( i, 0);
     BOOST_CHECK( tc->provides("scripting")->hasMember("func1"));
 
-    // define a function that calls func1:
-    statements = "void func2(void) { test.printNumber(\"[ENTER func2()] CycleCounter = \", CycleCounter); func1(); test.printNumber(\"[EXIT func2()] CycleCounter = \", CycleCounter); }\n";
+    // define a function that calls func1, yields and calls func1 again:
+    statements = "void func2(void) { test.printNumber(\"[ENTER func2()] CycleCounter = \", CycleCounter); func1(); yield; func1(); test.printNumber(\"[EXIT func2()] CycleCounter = \", CycleCounter); }\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
     BOOST_CHECK_EQUAL( i, 0);
@@ -371,9 +351,9 @@ BOOST_AUTO_TEST_CASE(TestScriptingFunctionWithYield)
 
     // invoke func2()
     statements="func2()\n";
-    r = sc->eval(statements); // deadlock!!!!
+    r = sc->eval(statements);
     BOOST_CHECK( r );
-    BOOST_CHECK_EQUAL( i, 4);
+    BOOST_CHECK_EQUAL( i, 6);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Additional patch for https://github.com/orocos-toolchain/rtt/pull/156 that enqueues the call in the function queue if the first execution as a message/operation returns without finishing the function (yield). Not sure if this is a good solution because the mix between operation and function semantics does not play nicely with the nested calls and has the potential to cause dead-locks.

Full patch against [toolchain-2.9](https://github.com/orocos-toolchain/rtt/tree/toolchain-2.9):
https://github.com/orocos-toolchain/rtt/compare/toolchain-2.9...meyerj:toolchain-2.9-fix-150-2

Note that the new test in [scripting_test.cpp:374](https://github.com/meyerj/rtt/pull/6/files#diff-f784007999255bc33aebc02d9993bbe5R374), where function `func2()` calls into `func1()` that yields dead-locks with all proposed branches so far, [toolchain-2.9](https://github.com/orocos-toolchain/rtt/tree/toolchain-2.9), [toolchain-2.9-fix-150](https://github.com/orocos-toolchain/rtt/pull/156) and [toolchain-2.9-fix-150-2](https://github.com/orocos-toolchain/rtt/compare/toolchain-2.9...meyerj:toolchain-2.9-fix-150-2).

I think the original patch in https://github.com/orocos-toolchain/rtt/pull/156 is still the cleanest solution, even though it breaks yielding in functions. Catching dead-locks caused by a "yield" in a nested call would be tricky and probably require a refactoring of the ExecutionEngine. It would have to explicitly track which thread is blocking on what resource and only execute the operations and/or functions that are necessary to unblock in case of a dead-lock. At the moment it is either "execute all pending operations" or "run all pending functions" even if it is not the correct time to do so.

@psoetens, @smits, @snrkiwi: Any comments?