### PR TITLE
transports::corba fix crash retrieving property name through corba

### DIFF
--- a/rtt/transports/corba/ConfigurationInterfaceI.cpp
+++ b/rtt/transports/corba/ConfigurationInterfaceI.cpp
@@ -155,10 +155,9 @@ RTT_corba_CConfigurationInterface_i::~RTT_corba_CConfigurationInterface_i (void)
     size_t index = 0;
     for( ; it != allprops.end(); ++it, ++index, ++dit) {
         ::RTT::corba::CConfigurationInterface::CProperty prop;
-        base::DataSourceBase::shared_ptr ds = getPropertyDataSource(*it);
         prop.name = CORBA::string_dup( it->c_str() );
         prop.description = CORBA::string_dup( dit->c_str() );
-        prop.type_name = CORBA::string_dup( ds->getTypeName().c_str() );
+        prop.type_name = getPropertyType((*it).c_str());
         ret[index] = prop;
     }
     return ret._retn();


### PR DESCRIPTION
When using Corba the underlying DataSource is used to resolve the Property type name.
If the Property can't be found a `DataSourceBase::shared_ptr();` is returned by `RTT_corba_CConfigurationInterface_i::getPropertyDataSource`.

Even in this case `ds->getTypeName()` was called leading to a segmentation fault.
Indeed `getTypeName()` is a pure virtual method for `DataSourceBase`.

This PR only avoids the segmentation fault while the original cause is related to the Property's name handling.
Indeed is possible to create a Property with a "." in its own name (see [Property.hpp](https://github.com/meyerj/rtt/blob/rdt-toolchain-2.9/rtt/Property.hpp#L104)), but when the function `findProperty()` (see [link](https://github.com/meyerj/rtt/blob/rdt-toolchain-2.9/rtt/PropertyBag.cpp#L305)) is called the argument `separator` is usually `"."` and the name before a dot should correspond to a PropertyBag.
So a check could be implemented at parsing level (from xml, script, console) that creates automatically a PropertyBag with the name before the dot and adds to it a Property with the name after the dot.