### PR TITLE
Add support for concurrent writes to DataObjectLockFree

### DIFF
--- a/rtt/base/BufferLockFree.hpp
+++ b/rtt/base/BufferLockFree.hpp
@@ -180,8 +180,8 @@ namespace RTT
 
         bool Push( param_t item)
         {
-            if ( capacity() == (size_type)bufs->size() ) {
-                if (!mcircular)
+            if (!mcircular) {
+                if ( capacity() == (size_type)bufs->size() )
                     return false;
                 // we will recover below in case of circular
             }

--- a/rtt/base/BufferLockFree.hpp
+++ b/rtt/base/BufferLockFree.hpp
@@ -180,9 +180,8 @@ namespace RTT
 
         bool Push( param_t item)
         {
-            if (!mcircular) {
-                if ( capacity() == (size_type)bufs->size() )
-                    return false;
+            if (!mcircular && ( capacity() == (size_type)bufs->size() )) {
+                return false;
                 // we will recover below in case of circular
             }
             Item* mitem = mpool->allocate();

--- a/rtt/base/ChannelElementBase.hpp
+++ b/rtt/base/ChannelElementBase.hpp
@@ -172,7 +172,7 @@ namespace RTT { namespace base {
         /** Signals that there is new data available on this channel
          * Forwards to \ref signal() unless overwritten in a derived class.
          */
-        virtual bool signalFrom(ChannelElementBase *caller) { return signal(); }
+        virtual bool signalFrom(ChannelElementBase *) { return signal(); }
 
         /**
          * This is called on the output half of a new connection by the connection

--- a/rtt/base/DataObjectLockFree.hpp
+++ b/rtt/base/DataObjectLockFree.hpp
@@ -289,11 +289,12 @@ namespace RTT
 
             // if next field is occupied (by read_ptr or counter),
             // go to next and check again...
-            while ( oro_atomic_read( &write_ptr->next->read_counter ) != 0 ||
-                    write_ptr->next == read_ptr )
+            PtrType next_write_ptr = writing->next;
+            while ( oro_atomic_read( &next_write_ptr->read_counter ) != 0 ||
+                    next_write_ptr == read_ptr )
                 {
-                    write_ptr = write_ptr->next;
-                    if (write_ptr == writing) {
+                    next_write_ptr = next_write_ptr->next;
+                    if (next_write_ptr == writing) {
                         oro_atomic_dec(&writing->write_lock);
                         return false; // nothing found, too many readers !
                     }
@@ -301,7 +302,7 @@ namespace RTT
 
             // we will be able to move, so replace read_ptr
             read_ptr  = writing;
-            write_ptr = write_ptr->next; // we checked this in the while loop
+            write_ptr = next_write_ptr; // we checked this in the while loop
             oro_atomic_dec(&writing->write_lock);
             return true;
         }

--- a/rtt/base/DataObjectLockFree.hpp
+++ b/rtt/base/DataObjectLockFree.hpp
@@ -295,7 +295,7 @@ namespace RTT
                     write_ptr = write_ptr->next;
                     if (write_ptr == writing) {
                         oro_atomic_dec(&writing->write_lock);
-                        return false; // nothing found, too many writers or readers !
+                        return false; // nothing found, too many readers !
                     }
                 }
 

--- a/rtt/base/DataObjectLockFree.hpp
+++ b/rtt/base/DataObjectLockFree.hpp
@@ -107,13 +107,14 @@ namespace RTT
          */
         struct DataBuf {
             DataBuf()
-                : data(), status(NoData), counter(), next()
+                : data(), status(NoData), read_counter(), write_counter(), next()
             {
-                oro_atomic_set(&counter, 0);
+                oro_atomic_set(&read_counter, 0);
+                oro_atomic_set(&write_counter, 0);
             }
             value_t data;
             FlowStatus status;
-            mutable oro_atomic_t counter;
+            mutable oro_atomic_t read_counter, write_counter;
             DataBuf* next;
         };
 
@@ -205,26 +206,30 @@ namespace RTT
             // could become write_ptr ( then we would read corrupted data).
             do {
                 reading = read_ptr;            // copy buffer location
-                oro_atomic_inc(&reading->counter); // lock buffer, no more writes
+                oro_atomic_inc(&reading->read_counter); // lock buffer, no more writes
                 // XXX smp_mb
                 if ( reading != read_ptr )     // if read_ptr changed,
-                    oro_atomic_dec(&reading->counter); // better to start over.
+                    oro_atomic_dec(&reading->read_counter); // better to start over.
                 else
                     break;
             } while ( true );
             // from here on we are sure that 'reading'
             // is a valid buffer to read from.
 
-            FlowStatus result = reading->status;
-            if (result == NewData) {
-                pull = reading->data;               // takes some time
-                reading->status = OldData;          // CAS?
-            } else if (((result == OldData) && copy_old_data) || copy_sample) {
+            // compare-and-swap FlowStatus field to make sure that only one reader
+            // returns NewData
+            FlowStatus result;
+            do {
+                result = reading->status;
+            } while((result != NoData) && !os::CAS(&reading->status, result, OldData));
+
+            if ((result == NewData) ||
+                ((result == OldData) && copy_old_data) || copy_sample) {
                 pull = reading->data;               // takes some time
             }
 
             // XXX smp_mb
-            oro_atomic_dec(&reading->counter);       // release buffer
+            oro_atomic_dec(&reading->read_counter);       // release buffer
             return result;
         }
 
@@ -249,38 +254,49 @@ namespace RTT
          */
         virtual bool Set( param_t push )
         {
-            /**
-             * This method can not be called concurrently (only one
-             * producer). With a minimum of 3 buffers, if the
-             * write_ptr+1 field is not occupied, it will remain so
-             * because the read_ptr is at write_ptr-1 (and can
-             * not increment the counter on write_ptr+1). Hence, no
-             * locking is needed.
-             */
-
             if (!initialized) {
                 log(Error) << "You set a lock-free data object of type " << internal::DataSourceTypeInfo<T>::getType() << " without initializing it with a data sample. "
                            << "This might not be real-time safe." << endlog();
                 data_sample(value_t(), true);
             }
 
-            // writeout in any case
-            PtrType writing = write_ptr;
+            PtrType writing;
+            do {
+                writing = write_ptr;            // copy buffer location
+                oro_atomic_inc(&writing->write_counter); // lock buffer, no more writes
+                // XXX smp_mb
+                if ( writing != write_ptr )     // if write_ptr changed,
+                    oro_atomic_dec(&writing->write_counter); // better to start over.
+                else if ( oro_atomic_read(&writing->write_counter) > 1 )
+                    oro_atomic_dec(&writing->write_counter); // better to start over.
+                else
+                    break;
+            } while ( true );
+            // from here on we are sure that 'writing'
+            // is a valid buffer to write to and we
+            // have exclusive access
+
+            // copy sample
             writing->data = push;
             writing->status = NewData;
 
             // if next field is occupied (by read_ptr or counter),
             // go to next and check again...
-            while ( oro_atomic_read( &write_ptr->next->counter ) != 0 || write_ptr->next == read_ptr )
+            while ( oro_atomic_read( &write_ptr->next->read_counter ) != 0 ||
+                    oro_atomic_read( &write_ptr->next->write_counter ) != 0 ||
+                    write_ptr->next == read_ptr )
                 {
                     write_ptr = write_ptr->next;
-                    if (write_ptr == writing)
-                        return false; // nothing found, to many readers !
+                    if (write_ptr == writing) {
+                        oro_atomic_dec(&writing->write_counter);
+                        return false; // nothing found, too many writers or readers !
+                    }
                 }
 
             // we will be able to move, so replace read_ptr
             read_ptr  = writing;
             write_ptr = write_ptr->next; // we checked this in the while loop
+            oro_atomic_dec(&writing->write_counter);
             return true;
         }
 
@@ -320,20 +336,25 @@ namespace RTT
             // could become write_ptr ( then we would read corrupted data).
             do {
                 reading = read_ptr;            // copy buffer location
-                oro_atomic_inc(&reading->counter); // lock buffer, no more writes
+                oro_atomic_inc(&reading->read_counter); // lock buffer, no more writes
                 // XXX smp_mb
                 if ( reading != read_ptr )     // if read_ptr changed,
-                    oro_atomic_dec(&reading->counter); // better to start over.
+                    oro_atomic_dec(&reading->read_counter); // better to start over.
                 else
                     break;
             } while ( true );
             // from here on we are sure that 'reading'
             // is a valid buffer to read from.
 
-            reading->status = NoData;
+            // compare-and-swap FlowStatus field to avoid the race condition
+            // where a reader replaces it by OldData
+            FlowStatus result;
+            do {
+                result = reading->status;
+            } while(!os::CAS(&reading->status, result, NoData));
 
             // XXX smp_mb
-            oro_atomic_dec(&reading->counter);       // release buffer
+            oro_atomic_dec(&reading->read_counter);       // release buffer
         }
     };
 }}

--- a/rtt/internal/ConnFactory.hpp
+++ b/rtt/internal/ConnFactory.hpp
@@ -163,11 +163,6 @@ namespace RTT
                 {
 #ifndef OROBLD_OS_NO_ASM
                 case ConnPolicy::LOCK_FREE:
-                    // DataObjectLockFree does not support multiple writers. We have to enforce lock policy LOCKED in this case.
-                    if (policy.buffer_policy == PerInputPort || policy.buffer_policy == Shared) {
-                        RTT::log(Error) << "Lock-free data objects do not allow multiple writers at this moment and therefore cannot be used in connection with the PerInputPort or Shared buffer policies." << endlog();
-                        return NULL;
-                    }
                     data_object.reset( new base::DataObjectLockFree<T>(initial_value, policy) );
                     break;
 #else

--- a/rtt/os/CAS.hpp
+++ b/rtt/os/CAS.hpp
@@ -59,7 +59,9 @@ namespace RTT
      * Overload of Compare And Swap for oro_atomic_t.
      */
     inline bool CAS( volatile oro_atomic_t* addr, const int expected, const int value) {
-        return expected == oro_cmpxchg(&oro_atomic_read(addr), expected, value);
+        // assume that oro_atomic_read(addr) returns a reference
+        volatile int &ref = oro_atomic_read(addr);
+        return expected == oro_cmpxchg(&ref, expected, value);
     }
 
 }}

--- a/rtt/os/CAS.hpp
+++ b/rtt/os/CAS.hpp
@@ -51,8 +51,15 @@ namespace RTT
      * return \a false.
      */
     template< class T, class V, class W >
-    bool CAS( volatile T* addr, const V& expected, const W& value) {
+    inline bool CAS( volatile T* addr, const V& expected, const W& value) {
         return expected == oro_cmpxchg(addr, expected, value);
+    }
+
+    /**
+     * Overload of Compare And Swap for oro_atomic_t.
+     */
+    inline bool CAS( volatile oro_atomic_t* addr, const int expected, const int value) {
+        return expected == oro_cmpxchg(&oro_atomic_read(addr), expected, value);
     }
 
 }}

--- a/rtt/os/Mutex.hpp
+++ b/rtt/os/Mutex.hpp
@@ -42,6 +42,8 @@
 #include "fosi.h"
 #include "../rtt-config.h"
 #include "rtt-os-fwd.hpp"
+#include "CAS.hpp"
+#include "Semaphore.hpp"
 #include "Time.hpp"
 
 #include <cassert>
@@ -69,11 +71,11 @@ namespace RTT
 		virtual void lock() =0;
 		virtual void unlock() =0;
 		virtual bool trylock() = 0;
-		virtual bool timedlock(Seconds s) = 0;
+		virtual bool timedlock(Seconds) = 0;
         virtual void lock_shared() {}
         virtual void unlock_shared() {}
         virtual bool trylock_shared() { return false; }
-        virtual bool timedlock_shared(Seconds s) { return false; }
+        virtual bool timedlock_shared(Seconds) { return false; }
 	};
 
 
@@ -330,86 +332,108 @@ namespace RTT
     };
 
     /**
-     * @brief An object oriented wrapper around a shared mutex (multiple readers allowed).
+     * @brief An object oriented wrapper around a shared mutex
+     * (multiple readers allowed, but only one writer with exclusive access).
      *
      * A mutex can only be  unlock()'ed, by the thread which lock()'ed
      * it. A trylock is a non blocking lock action which fails or succeeds.
+     *
+     * Implementation is motivated by
+     * http://preshing.com/20150316/semaphores-are-surprisingly-versatile/#a-lightweight-semaphore-with-partial-spinning.
      *
      * @see MutexLock, MutexTryLock, SharedMutexLock, SharedMutexTryLock, Mutex
      */
     class RTT_API SharedMutex : public MutexInterface
     {
-#ifndef ORO_OS_USE_BOOST_THREAD
     protected:
-        rt_mutex_t m;
-        rt_cond_t shared_cond;
-        rt_cond_t exclusive_cond;
-        unsigned shared_count;
-        bool exclusive;
+        typedef unsigned int Status;
+        oro_atomic_t status;
+        Semaphore read_semaphore;
+        Semaphore write_semaphore;
+
+        static const Status one_reader       = (1 << 0);
+        static const Status one_wait_to_read = (1 << 10);
+        static const Status one_writer       = (1 << 20);
+        static const Status status_mask      = (1 << 10) - 1;
+
+        static inline unsigned int readers(Status status) {
+            return (status & status_mask);
+        }
+        static inline unsigned int waitToRead(Status status) {
+            return ((status >> 10) & status_mask);
+        }
+        static inline unsigned int writers(Status status) {
+            return ((status >> 20) & status_mask);
+        }
+
     public:
         /**
         * Initialize a shared Mutex.
         */
         SharedMutex()
-            : shared_count(0)
-            , exclusive(false)
+            : read_semaphore(0)
+            , write_semaphore(0)
         {
-            rtos_mutex_init( &m );
-            rtos_cond_init( &shared_cond );
-            rtos_cond_init( &exclusive_cond );
+            ORO_ATOMIC_SETUP( &status, 0 );
         }
 
         /**
         * Destroy a shared Mutex.
-        * If the Mutex is still locked, the RTOS
-        * will not be asked to clean up its resources.
         */
         virtual ~SharedMutex()
         {
-            if ( trylock() ) {
-                unlock();
-                rtos_mutex_destroy( &m );
-                rtos_cond_destroy( &shared_cond );
-                rtos_cond_destroy( &exclusive_cond );
-            }
+            ORO_ATOMIC_CLEANUP( &status );
         }
 
         virtual void lock ()
         {
-            rtos_mutex_lock( &m );
-            while (shared_count || exclusive) {
-                rtos_cond_wait(&exclusive_cond, &m);
+            Status old_status, new_status;
+            do {
+                new_status = old_status = (Status) oro_atomic_read( &status );
+                new_status += one_writer;
+                assert(writers(new_status) > 0);  // overflow?
+            } while(!CAS(&status, (int) old_status, (int) new_status));
+
+            if (readers(old_status) > 0 || writers(old_status) > 0) {
+                write_semaphore.wait();
             }
-            exclusive = true;
-            rtos_mutex_unlock( &m );
         }
 
         virtual void unlock()
         {
-            rtos_mutex_lock( &m );
-            assert(shared_count == 0);
-            assert(exclusive);
-            exclusive = false;
-            rtos_cond_broadcast( &exclusive_cond );
-            rtos_cond_broadcast( &shared_cond );
-            rtos_mutex_unlock( &m );
+            Status old_status, new_status;
+            unsigned int wait_to_read = 0;
+            do {
+                new_status = old_status = (Status) oro_atomic_read( &status );
+                assert(readers(old_status) == 0);
+                assert(writers(old_status) > 0);
+                new_status -= one_writer;
+                wait_to_read = waitToRead(old_status);
+                if (wait_to_read > 0) {
+                    // all waiting threads can be unblocked
+                    new_status = (new_status & (status_mask << 20)) | wait_to_read;
+                }
+            } while(!CAS(&status, (int) old_status, (int) new_status));
+
+            // Signal threads that have been waiting for a read lock
+            if (wait_to_read > 0) {
+                for(unsigned int i = 0; i < wait_to_read; ++i) read_semaphore.signal();
+            } else
+            // ... or signal a thread that has been waiting for a write lock
+            if (writers(old_status) > 1) {
+                write_semaphore.signal();
+            }
         }
 
         /**
         * Try to lock this mutex exclusively
         *
-        * @return true when the locking succeeded, false otherwise
+        * @note not implemented for this type of mutex
+        * @return false
         */
         virtual bool trylock()
         {
-            rtos_mutex_lock( &m );
-            if (shared_count || exclusive) {
-                rtos_mutex_unlock( &m );
-                return false;
-            }
-            exclusive = true;
-            rtos_mutex_unlock( &m );
-            return true;
+            return false;
         }
 
         /**
@@ -417,21 +441,14 @@ namespace RTT
         * than the specified timeout.
         *
         * @param  s The maximum time to wait before aqcuiring the lock.
-        * @return true when the locking succeeded, false otherwise
+        *
+        * @note not implemented for this type of mutex
+        * @return false
         */
         virtual bool timedlock(Seconds s)
         {
-            RTT::nsecs abs_time = rtos_get_time_ns() + Seconds_to_nsecs(s);
-            rtos_mutex_lock( &m );
-            while (shared_count || exclusive) {
-                if ( rtos_cond_timedwait( &exclusive_cond, &m, abs_time ) != 0 ) {
-                    rtos_mutex_unlock( &m );
-                    return false;
-                }
-            }
-            exclusive = true;
-            rtos_mutex_unlock( &m );
-            return true;
+            (void) s;
+            return false;
         }
 
         /**
@@ -439,124 +456,22 @@ namespace RTT
          */
         void lock_shared ()
         {
-            rtos_mutex_lock( &m );
-            while (exclusive) {
-                rtos_cond_wait(&shared_cond, &m);
-            }
-            shared_count++;
-            rtos_mutex_unlock( &m );
-        }
-
-        /**
-         * Release shared ownership of this mutex.
-         */
-        virtual void unlock_shared()
-        {
-            rtos_mutex_lock( &m );
-            assert(shared_count > 0);
-            assert(!exclusive);
-            if (shared_count > 0) shared_count--;
-            rtos_cond_broadcast( &exclusive_cond );
-            rtos_mutex_unlock( &m );
-        }
-
-        /**
-        * Attempt to obtain shared ownership of this mutex
-        *
-        * @return true when the locking succeeded, false otherwise
-        */
-        virtual bool trylock_shared()
-        {
-            rtos_mutex_lock( &m );
-            if (exclusive) {
-                rtos_mutex_unlock( &m );
-                return false;
-            }
-            shared_count++;
-            rtos_mutex_unlock( &m );
-            return true;
-        }
-
-        /**
-        * Attempt to obtain shared ownership of this mutex, but don't wait longer for the lock
-        * than the specified timeout.
-        *
-        * @param  s The maximum time to wait before aqcuiring the lock.
-        * @return true when the locking succeeded, false otherwise
-        */
-        virtual bool timedlock_shared(Seconds s)
-        {
-            RTT::nsecs abs_time = rtos_get_time_ns() + Seconds_to_nsecs(s);
-            rtos_mutex_lock( &m );
-            while (exclusive) {
-                if ( rtos_cond_timedwait( &shared_cond, &m, abs_time ) != 0 ) {
-                    rtos_mutex_unlock( &m );
-                    return false;
+            Status old_status, new_status;
+            do {
+                new_status = old_status = (Status) oro_atomic_read( &status );
+                if (writers(old_status) > 0) {
+                    new_status += one_wait_to_read;
+                    assert(waitToRead(new_status) > 0);  // overflow?
+                } else {
+                    new_status += one_reader;
+                    assert(readers(new_status) > 0);  // overflow?
                 }
+            } while(!CAS(&status, (int) old_status, (int) new_status));
+
+            // wait until all writers are finished
+            if (writers(old_status) > 0) {
+                read_semaphore.wait();
             }
-            shared_count++;
-            rtos_mutex_unlock( &m );
-            return true;
-        }
-
-#else
-    protected:
-        boost::shared_mutex sharedm;
-    public:
-        /**
-         * Initialize a shared Mutex.
-         */
-        SharedMutex()
-        {
-        }
-
-        /**
-        * Destroy a SharedMutex.
-        * If the SharedMutex is still locked, the RTOS
-        * will not be asked to clean up its resources.
-        */
-        virtual ~SharedMutex()
-        {
-        }
-
-        void lock ()
-        {
-            sharedm.lock();
-        }
-
-        virtual void unlock()
-        {
-            sharedm.unlock();
-        }
-
-        /**
-        * Try to lock this mutex
-        *
-        * @return true when the locking succeeded, false otherwise
-        */
-        virtual bool trylock()
-        {
-            return sharedm.try_lock();
-        }
-
-        /**
-        * Lock this mutex, but don't wait longer for the lock
-        * than the specified timeout.
-        *
-        * @param  s The maximum time to wait before aqcuiring the lock.
-        * @return true when the locking succeeded, false otherwise
-        */
-        virtual bool timedlock(Seconds s)
-        {
-            return sharedm.timed_lock( boost::posix_time::microseconds( Seconds_to_nsecs(s)/1000 ) );
-        }
-
-        /**
-         * Obtain shared ownership of this mutex.
-         */
-        void lock_shared ()
-        {
-            sharedm.lock_shared();
         }
 
         /**
@@ -564,17 +479,28 @@ namespace RTT
          */
         virtual void unlock_shared()
         {
-            sharedm.unlock_shared();
+            Status old_status, new_status;
+            do {
+                new_status = old_status = (Status) oro_atomic_read( &status );
+                assert(readers(old_status) > 0);
+                new_status -= one_reader;
+            } while(!CAS(&status, (int) old_status, (int) new_status));
+
+            // one writer thread can be unblocked if there are no more readers
+            if (readers(old_status) == 1 && writers(old_status) > 0) {
+                write_semaphore.signal();
+            }
         }
 
         /**
         * Attempt to obtain shared ownership of this mutex
         *
-        * @return true when the locking succeeded, false otherwise
+        * @note not implemented for this type of mutex
+        * @return false
         */
         virtual bool trylock_shared()
         {
-            return sharedm.try_lock_shared();
+            return false;
         }
 
         /**
@@ -582,13 +508,15 @@ namespace RTT
         * than the specified timeout.
         *
         * @param  s The maximum time to wait before aqcuiring the lock.
-        * @return true when the locking succeeded, false otherwise
+        *
+        * @note not implemented for this type of mutex
+        * @return false
         */
         virtual bool timedlock_shared(Seconds s)
         {
-            return sharedm.timed_lock_shared( boost::posix_time::microseconds( Seconds_to_nsecs(s)/1000 ) );
+            (void) s;
+            return false;
         }
-#endif
     };
 
 }}

--- a/rtt/os/oro_arch_interface.h
+++ b/rtt/os/oro_arch_interface.h
@@ -55,12 +55,22 @@ void oro_atomic_set(oro_atomic_t* a, int n);
 void oro_atomic_add(oro_atomic_t *a, int n);
 
 /**
- * Substract n from a
+ * Add n to a and return the new value
+ */
+int oro_atomic_add_return(oro_atomic_t *a, int n);
+
+/**
+ * Subtract n from a
  */
 void oro_atomic_sub(int n, oro_atomic_t *a, int n);
 
 /**
- * Substract n from a and test for zero
+ * Subtract n from a and return the new value
+ */
+int oro_atomic_sub_return(int n, oro_atomic_t *a, int n);
+
+/**
+ * Subtract n from a and test for zero
  */
 int oro_atomic_sub_and_test(oro_atomic_t *a, int n);
 
@@ -70,9 +80,19 @@ int oro_atomic_sub_and_test(oro_atomic_t *a, int n);
 void oro_atomic_inc(oro_atomic_t *a);
 
 /**
+ * Increment a atomically and return the new value
+ */
+int oro_atomic_inc_return(oro_atomic_t *a);
+
+/**
  * Decrement a atomically
  */
 void oro_atomic_dec(oro_atomic_t *a);
+
+/**
+ * Decrement a atomically and return the new value
+ */
+int oro_atomic_dec_return(oro_atomic_t *a);
 
 /**
  * Decrement a atomically and test for zero.

--- a/rtt/os/oro_gcc/oro_arch.h
+++ b/rtt/os/oro_gcc/oro_arch.h
@@ -27,7 +27,15 @@ static __inline__ void oro_atomic_add(oro_atomic_t *a_int, int n)
 }
 
 /**
- * Substract n from a_int
+ * Add n to a_int and return the new value
+ */
+static __inline__ int oro_atomic_add_return(oro_atomic_t *a_int, int n)
+{
+    return __sync_add_and_fetch(&a_int->cnt, n);
+}
+
+/**
+ * Subtract n from a_int
  */
 static __inline__ void oro_atomic_sub(oro_atomic_t *a_int, int n)
 {
@@ -35,7 +43,15 @@ static __inline__ void oro_atomic_sub(oro_atomic_t *a_int, int n)
 }
 
 /**
- * Substract n from a_int and test for zero
+ * Subtract n from a_int and return the new value
+ */
+static __inline__ int oro_atomic_sub_return(oro_atomic_t *a_int, int n)
+{
+    return __sync_sub_and_fetch(&a_int->cnt, n);
+}
+
+/**
+ * Subtract n from a_int and test for zero
  */
 static __inline__ int oro_atomic_sub_and_test(oro_atomic_t *a_int, int n)
 {
@@ -51,11 +67,27 @@ static __inline__ void oro_atomic_inc(oro_atomic_t *a_int)
 }
 
 /**
+ * Increment a_int atomically and return the new value
+ */
+static __inline__ int oro_atomic_inc_return(oro_atomic_t *a_int)
+{
+    return __sync_fetch_and_add(&a_int->cnt, 1);
+}
+
+/**
  * Decrement a_int atomically
  */
 static __inline__ void oro_atomic_dec(oro_atomic_t *a_int)
 {
     (void)__sync_fetch_and_sub(&a_int->cnt, 1);
+}
+
+/**
+ * Decrement a_int atomically and return the new value
+ */
+static __inline__ int oro_atomic_dec_return(oro_atomic_t *a_int)
+{
+    return __sync_fetch_and_sub(&a_int->cnt, 1);
 }
 
 /**

--- a/rtt/os/oro_i386/oro_arch.h
+++ b/rtt/os/oro_i386/oro_arch.h
@@ -64,12 +64,28 @@ static __inline__ void oro_atomic_add( oro_atomic_t *v, int i)
 		:"ir" (i), "m" (v->counter));
 }
 
+static __inline__ int oro_atomic_add_return( oro_atomic_t *v, int i)
+{
+  /* Modern 486+ processor */
+	int __i = i;
+	__asm__ __volatile__(
+		ORO_LOCK "xaddl %0, %1"
+		: "+r" (i), "+m" (v->counter)
+		: : "memory");
+	return i + __i;
+}
+
 static __inline__ void oro_atomic_sub( oro_atomic_t *v, int i)
 {
 	__asm__ __volatile__(
 		ORO_LOCK "subl %1,%0"
 		:"=m" (v->counter)
 		:"ir" (i), "m" (v->counter));
+}
+
+static __inline__ int oro_atomic_sub_return( oro_atomic_t *v, int i)
+{
+	return oro_atomic_add_return( v, -i );
 }
 
 static __inline__ void oro_atomic_inc(oro_atomic_t *v)
@@ -87,6 +103,9 @@ static __inline__ void oro_atomic_dec(oro_atomic_t *v)
 		:"=m" (v->counter)
 		:"m" (v->counter));
 }
+
+#define oro_atomic_inc_return(v) (oro_atomic_add_return(v, 1))
+#define oro_atomic_dec_return(v) (oro_atomic_sub_return(v, 1))
 
 static __inline__ int oro_atomic_dec_and_test(oro_atomic_t *v)
 {

--- a/rtt/os/oro_noasm/oro_arch.h
+++ b/rtt/os/oro_noasm/oro_arch.h
@@ -73,9 +73,23 @@ static __inline__ void oro_atomic_add(oro_atomic_t *a_int, int n )
   rtos_mutex_lock(&((a_int)->m)); (a_int)->cnter += n; rtos_mutex_unlock(&((a_int)->m));
 }
 
+static __inline__ int oro_atomic_add_return(oro_atomic_t *a_int, int n )
+{
+  int new_value;
+  rtos_mutex_lock(&((a_int)->m)); new_value = ((a_int)->cnter += n); rtos_mutex_unlock(&((a_int)->m));
+  return new_value;
+}
+
 static __inline__ void oro_atomic_sub(oro_atomic_t *a_int, int n )
 {
   rtos_mutex_lock(&((a_int)->m)); (a_int)->cnter -= n; rtos_mutex_unlock(&((a_int)->m));
+}
+
+static __inline__ int oro_atomic_sub_return(oro_atomic_t *a_int, int n )
+{
+  int new_value;
+  rtos_mutex_lock(&((a_int)->m)); new_value = ((a_int)->cnter -= n); rtos_mutex_unlock(&((a_int)->m));
+  return new_value;
 }
 
 static __inline__ int oro_atomic_add_and_test(oro_atomic_t *a_int, int n )
@@ -97,9 +111,23 @@ static __inline__ void oro_atomic_inc(oro_atomic_t *a_int)
   rtos_mutex_lock(&((a_int)->m)); ++((a_int)->cnter) ; rtos_mutex_unlock(&((a_int)->m));
 }
 
+static __inline__ int oro_atomic_inc_return(oro_atomic_t *a_int)
+{
+  int new_value;
+  rtos_mutex_lock(&((a_int)->m)); new_value = (++((a_int)->cnter)) ; rtos_mutex_unlock(&((a_int)->m));
+  return new_value;
+}
+
 static __inline__ void oro_atomic_dec(oro_atomic_t *a_int)
 {
   rtos_mutex_lock(&((a_int)->m)); --((a_int)->cnter) ; rtos_mutex_unlock(&((a_int)->m));
+}
+
+static __inline__ int oro_atomic_dec_return(oro_atomic_t *a_int)
+{
+  int new_value;
+  rtos_mutex_lock(&((a_int)->m)); new_value = (--((a_int)->cnter)) ; rtos_mutex_unlock(&((a_int)->m));
+  return new_value;
 }
 
 static __inline__ int oro_atomic_dec_and_test(oro_atomic_t *a_int)

--- a/rtt/os/oro_x86_64/oro_arch.h
+++ b/rtt/os/oro_x86_64/oro_arch.h
@@ -64,12 +64,27 @@ static __inline__ void oro_atomic_add(oro_atomic_t *v, int i)
 		:"ir" (i), "m" (v->counter));
 }
 
+static __inline__ int oro_atomic_add_return(oro_atomic_t *v, int i)
+{
+	int __i = i;
+	__asm__ __volatile__(
+		ORO_LOCK "xaddl %0, %1"
+		: "+r" (i), "+m" (v->counter)
+		: : "memory");
+	return i + __i;
+}
+
 static __inline__ void oro_atomic_sub(oro_atomic_t *v, int i)
 {
 	__asm__ __volatile__(
 		ORO_LOCK "subl %1,%0"
 		:"=m" (v->counter)
 		:"ir" (i), "m" (v->counter));
+}
+
+static __inline__ int oro_atomic_sub_return(oro_atomic_t *v, int i)
+{
+	return oro_atomic_add_return(v, -i);
 }
 
 static __inline__ int oro_atomic_sub_and_test(oro_atomic_t *v, int i)
@@ -98,6 +113,9 @@ static __inline__ void oro_atomic_dec(oro_atomic_t *v)
 		:"=m" (v->counter)
 		:"m" (v->counter));
 }
+
+#define oro_atomic_inc_return(v)  (oro_atomic_add_return(v, 1))
+#define oro_atomic_dec_return(v)  (oro_atomic_sub_return(v, 1))
 
 static __inline__ int oro_atomic_dec_and_test(oro_atomic_t *v)
 {

--- a/tests/buffers_test.cpp
+++ b/tests/buffers_test.cpp
@@ -675,6 +675,7 @@ void BuffersDataFlowTest::testBufMultiThreaded(int number_of_writers, int number
     BOOST_FOREACH(ThreadPool<BufferWriter>::value_type &writer, writers) {
         BOOST_REQUIRE( !writer.second->isRunning() );
         total_writes += writer.first->writes;
+        total_dropped += writer.first->dropped;
         BOOST_CHECK_GT(writer.first->writes, 0);
     }
     BOOST_FOREACH(ThreadPool<BufferReader>::value_type &reader, readers) {
@@ -711,6 +712,7 @@ void BuffersDataFlowTest::testDObjMultiThreaded(int number_of_writers, int numbe
     BOOST_FOREACH(ThreadPool<DataObjectWriter>::value_type &writer, writers) {
         BOOST_REQUIRE( !writer.second->isRunning() );
         total_writes += writer.first->writes;
+        total_dropped += writer.first->dropped;
         BOOST_CHECK_GT(writer.first->writes, 0);
     }
     BOOST_FOREACH(ThreadPool<DataObjectReader>::value_type &reader, readers) {
@@ -1178,10 +1180,24 @@ BOOST_AUTO_TEST_CASE( testBufLocked4Writers4Readers )
     delete buffer;
 }
 
+BOOST_AUTO_TEST_CASE( testDObjLockFree4Writers1Reader )
+{
+    dataobj = new DataObjectLockFree<Dummy>(Dummy(), /* max_threads = */ 5);
+    testDObjMultiThreaded(4, 1);
+    delete dataobj;
+}
+
 BOOST_AUTO_TEST_CASE( testDObjLockFreeSingleWriter4Readers )
 {
     dataobj = new DataObjectLockFree<Dummy>(Dummy(), /* max_threads = */ 5);
     testDObjMultiThreaded(1, 4);
+    delete dataobj;
+}
+
+BOOST_AUTO_TEST_CASE( testDObjLockFree4Writers4Readers )
+{
+    dataobj = new DataObjectLockFree<Dummy>(Dummy(), /* max_threads = */ 8);
+    testDObjMultiThreaded(4, 4);
     delete dataobj;
 }
 

--- a/tests/corba_test.cpp
+++ b/tests/corba_test.cpp
@@ -660,8 +660,8 @@ BOOST_AUTO_TEST_CASE( testSharedConnections )
     BOOST_CHECK( ports2->createConnection("mo", ports2, "mi", policy) );
     BOOST_CHECK( mi3->connected() );
     BOOST_CHECK( mo2->connected() );
-    BOOST_ASSERT( mi2->getManager()->getSharedConnection() );
-    BOOST_ASSERT( mi3->getManager()->getSharedConnection() );
+    BOOST_REQUIRE( mi2->getManager()->getSharedConnection() );
+    BOOST_REQUIRE( mi3->getManager()->getSharedConnection() );
     BOOST_CHECK_EQUAL( mi2->getManager()->getSharedConnection()->getName(), mi3->getManager()->getSharedConnection()->getName() );
     BOOST_CHECK_EQUAL( mi3->read(value), NoData );
     testPortDataConnection(); // communication between mo and mi should work the same as for private connections
@@ -690,8 +690,8 @@ BOOST_AUTO_TEST_CASE( testSharedConnections )
     BOOST_CHECK( ports2->createConnection("mo", ports2, "mi", policy) );
     BOOST_CHECK( mi3->connected() );
     BOOST_CHECK( mo2->connected() );
-    BOOST_ASSERT( mi2->getManager()->getSharedConnection() );
-    BOOST_ASSERT( mi3->getManager()->getSharedConnection() );
+    BOOST_REQUIRE( mi2->getManager()->getSharedConnection() );
+    BOOST_REQUIRE( mi3->getManager()->getSharedConnection() );
     BOOST_CHECK_EQUAL( mi2->getManager()->getSharedConnection()->getName(), mi3->getManager()->getSharedConnection()->getName() );
     BOOST_CHECK_EQUAL( mi3->read(value), NoData );
 #ifndef RTT_CORBA_PORTS_DISABLE_SIGNAL

--- a/tests/dataflow_performance_test.cpp
+++ b/tests/dataflow_performance_test.cpp
@@ -294,18 +294,28 @@ template <typename T, PortTypes> struct Adaptor;
 
 #if !RTT_VERSION_GTE(2,8,99)
     typedef enum { WriteSuccess, WriteFailure, NotConnected } WriteStatus;
-    typedef enum { UnspecifiedReadPolicy, ReadUnordered, ReadShared } ReadPolicy;
-    typedef enum { UnspecifiedWritePolicy, WritePrivate, WriteShared } WritePolicy;
+    typedef enum { UnspecifiedBufferPolicy, PerConnection, PerInputPort, PerOutputPort, Shared } BufferPolicy;
 
     // dummy RTT v2.8.99 compatible ConnPolicy
     struct ConnPolicy : public RTT::ConnPolicy {
         static const bool PUSH = false;
         static const bool PULL = true;
 
-        ReadPolicy read_policy;
-        WritePolicy write_policy;
-        bool mandatory;
+        int buffer_policy;
         int max_threads;
+        bool mandatory;
+
+        ConnPolicy() :  RTT::ConnPolicy(), buffer_policy(), max_threads(), mandatory() {}
+        explicit ConnPolicy(int type) : RTT::ConnPolicy(type), buffer_policy(), max_threads(), mandatory() {}
+        explicit ConnPolicy(int type, int lock_policy) : RTT::ConnPolicy(type, lock_policy), buffer_policy(), max_threads(), mandatory() {}
+
+        ConnPolicy &operator==(const RTT::ConnPolicy &other) {
+            static_cast<RTT::ConnPolicy&>(*this) = other;
+            buffer_policy = 0;
+            max_threads = 0;
+            mandatory = false;
+            return *this;
+        }
     };
 
 #else
@@ -410,9 +420,9 @@ template <typename T, PortTypes> struct Adaptor;
         }
 
         std::string pull;
-        switch(cp.pull) {
-            case ConnPolicy::PUSH: pull = "PUSH"; break;
-            case ConnPolicy::PULL: pull = "PULL"; break;
+        switch(int(cp.pull)) {
+            case int(ConnPolicy::PUSH): pull = "PUSH"; break;
+            case int(ConnPolicy::PULL): pull = "PULL"; break;
         }
 
         os << pull << " ";

--- a/tests/dataflow_performance_test.cpp
+++ b/tests/dataflow_performance_test.cpp
@@ -466,30 +466,39 @@ public:
         : Derived(), _counter_details(new CopyAndAssignmentCountedDetails)
     {
         ORO_ATOMIC_SETUP(&_write_guard, 1);
+        ORO_ATOMIC_SETUP(&_read_guard, 1);
     }
     CopyAndAssignmentCounted(const value_type &value)
         : Derived(value), _counter_details(new CopyAndAssignmentCountedDetails)
     {
-      ORO_ATOMIC_SETUP(&_write_guard, 1);
+        ORO_ATOMIC_SETUP(&_write_guard, 1);
+        ORO_ATOMIC_SETUP(&_read_guard, 1);
     }
     CopyAndAssignmentCounted(const this_type &other)
         : Derived(other), _counter_details(other._counter_details)
     {
-      ORO_ATOMIC_SETUP(&_write_guard, 1);
+        ORO_ATOMIC_SETUP(&_write_guard, 1);
+        ORO_ATOMIC_SETUP(&_read_guard, 1);
         oro_atomic_inc(&(_counter_details->copies));
     }
     ~CopyAndAssignmentCounted() {
         ORO_ATOMIC_CLEANUP(&_write_guard);
+        ORO_ATOMIC_CLEANUP(&_read_guard);
     }
 
     this_type &operator=(const value_type &) { throw std::runtime_error("Cannot assign CopyAndAssignmentCounted type from its value_type directly!"); }
     this_type &operator=(const this_type &other) {
-        BOOST_ASSERT_MSG(oro_atomic_dec_and_test(&_write_guard), "Conflicting assignment detected!");
+        if (this == &other) return *this;
+        BOOST_ASSERT_MSG(oro_atomic_dec_and_test(&_write_guard), "Conflicting assignment detected: instance is concurrently being assigned by another thread!");
+        oro_atomic_inc(&other._read_guard);
+        BOOST_ASSERT_MSG(oro_atomic_dec_and_test(&_read_guard), "Conflicting assignment detected: instance being assigned is concurrently read by another thread!");
         static_cast<value_type &>(*this) = other;
         _counter_details = other._counter_details;
         oro_atomic_inc(&(_counter_details->assignments));
+        oro_atomic_inc(&_read_guard);
+        oro_atomic_dec(&other._read_guard);
         oro_atomic_inc(&_write_guard);
-        return *static_cast<this_type *>(this);
+        return *this;
     }
 
     int getCopyCount() { return oro_atomic_read(&(_counter_details->copies)); }
@@ -504,6 +513,7 @@ public:
 private:
     boost::intrusive_ptr<CopyAndAssignmentCountedDetails> _counter_details;
     oro_atomic_t _write_guard;
+    mutable oro_atomic_t _read_guard;
 };
 
 template <typename T>
@@ -1307,7 +1317,7 @@ public:
             total_read_timer_by_status[OldData] += (*task)->timer_by_status[OldData];
             total_read_timer_by_status[NoData] += (*task)->timer_by_status[NoData];
         }
-        std::cout << "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------" << std::endl;
+        std::cout << "---------------------------------------------------------------------------------------------------------------------------------------------------------------------" << std::endl;
         std::cout << std::left
                   << " " << std::setw(30) << "Total"
                   << " " << std::setw(16) << ""

--- a/tests/dataflow_performance_test.cpp
+++ b/tests/dataflow_performance_test.cpp
@@ -489,12 +489,20 @@ public:
     this_type &operator=(const value_type &) { throw std::runtime_error("Cannot assign CopyAndAssignmentCounted type from its value_type directly!"); }
     this_type &operator=(const this_type &other) {
         if (this == &other) return *this;
-        BOOST_REQUIRE_MESSAGE(oro_atomic_dec_and_test(&_write_guard), "Conflicting assignment detected: instance is concurrently being assigned by another thread!");
+
+        // lock guards to detect concurrent reading and writing
+        if (!oro_atomic_dec_and_test(&_write_guard))
+            throw std::runtime_error("Conflicting assignment detected: instance is concurrently being assigned by another thread!");
         oro_atomic_inc(&other._read_guard);
-        BOOST_REQUIRE_MESSAGE(oro_atomic_dec_and_test(&_read_guard), "Conflicting assignment detected: instance being assigned is concurrently read by another thread!");
+        if (!oro_atomic_dec_and_test(&_read_guard))
+            throw std::runtime_error("Conflicting assignment detected: instance being assigned is concurrently read by another thread!");
+
+        // copy
         static_cast<value_type &>(*this) = other;
         _counter_details = other._counter_details;
         oro_atomic_inc(&(_counter_details->assignments));
+
+        // cleanup guards
         oro_atomic_inc(&_read_guard);
         oro_atomic_dec(&other._read_guard);
         oro_atomic_inc(&_write_guard);
@@ -755,6 +763,10 @@ public:
         number_of_cycles_ = 0;
         desired_number_of_cycles_ = n;
         return *this;
+    }
+
+    ~ReaderWriterTaskContextBase() {
+        BOOST_REQUIRE(!this->inException());
     }
 
     void afterUpdateHook(bool trigger)

--- a/tests/dataflow_performance_test.cpp
+++ b/tests/dataflow_performance_test.cpp
@@ -1046,12 +1046,12 @@ public:
     Readers readers;
     Tasks tasks;
 
-    TestRunner(const std::string &name, const TestOptions &options)
+    TestRunner(const TestOptions &options)
         : options_(options)
     {
 
         for(std::size_t index = 0; index < options_.NumberOfWriters; ++index) {
-            WriterPtr writer(new Writer<T,PortType>(name + "Writer", index, options_.SampleSize, options_.KeepLastWrittenValue));
+            WriterPtr writer(new Writer<T,PortType>("Writer", index, options_.SampleSize, options_.KeepLastWrittenValue));
             writers.push_back(writer);
             tasks.push_back(writer);
             switch(options_.WriteMode) {
@@ -1073,7 +1073,7 @@ public:
         }
 
         for(std::size_t index = 0; index < options_.NumberOfReaders; ++index) {
-            ReaderPtr reader(new Reader<T,PortType>(name + "Reader", index, options_.ReadLoop, options_.CopyOldData));
+            ReaderPtr reader(new Reader<T,PortType>("Reader", index, options_.ReadLoop, options_.CopyOldData));
             readers.push_back(reader);
             tasks.push_back(reader);
             switch(options_.ReadMode) {
@@ -1353,342 +1353,281 @@ private:
     TestOptions options_;
 };
 
-// Registers the test suite into the 'registry'
-BOOST_AUTO_TEST_SUITE( DataFlowPerformanceTest )
-
-BOOST_AUTO_TEST_CASE( dataConnections )
-{
+template <PortTypes PortType, typename Enabled = void>
+struct DataFlowPerformanceTest_ {
     TestOptions options;
-    const PortTypes PortType = DataPortType;
     typedef TestRunner<SampleType,PortType> RunnerType;
+    typename RunnerType::shared_ptr runner;
 
+    DataFlowPerformanceTest_();
+    void run() {
+        std::cout << runner->getOptions();
+        BOOST_CHECK( runner->connectAll() );
+        BOOST_CHECK( runner->run() );
+
+        runner->printStats();
+        std::cout << std::endl;
+    }
+};
+
+template <>
+DataFlowPerformanceTest_<DataPortType>::DataFlowPerformanceTest_()
+{
     options.policy.type = ConnPolicy::DATA;
 //    options.policy.lock_policy = ConnPolicy::LOCK_FREE;
-
-#if (RTT_VERSION_MAJOR >= 2)
-    // 7 writers, 1 reader, PerConnection
-    {
-        options.NumberOfWriters = 7;
-        options.NumberOfReaders = 1;
-        options.policy.buffer_policy = PerConnection;
-        RunnerType::shared_ptr runner(new RunnerType("dataPerConnection", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-#endif
-
-#if (RTT_VERSION_MAJOR == 1) || RTT_VERSION_GTE(2,8,99)
-    // 7 writers, 1 reader, PerInputPort
-    {
-        options.NumberOfWriters = 7;
-        options.NumberOfReaders = 1;
-        options.policy.buffer_policy = PerInputPort;
-        RunnerType::shared_ptr runner(new RunnerType("dataPerInputPort", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-#endif
-
-#if (RTT_VERSION_MAJOR >= 2)
-    // 1 writer, 7 readers, PerConnection
-    {
-        options.NumberOfWriters = 1;
-        options.NumberOfReaders = 7;
-        options.policy.buffer_policy = PerConnection;
-        RunnerType::shared_ptr runner(new RunnerType("dataPerConnection", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-#endif
-
-#if (RTT_VERSION_MAJOR == 1) || RTT_VERSION_GTE(2,8,99)
-    // 1 writer, 7 readers, PerOutputPort
-    {
-        options.NumberOfWriters = 1;
-        options.NumberOfReaders = 7;
-        options.policy.buffer_policy = PerOutputPort;
-        RunnerType::shared_ptr runner(new RunnerType("dataPerOutputPort", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-#endif
-
-#if (RTT_VERSION_MAJOR >= 2)
-    // 4 writers, 4 readers, PerConnection
-    {
-        options.NumberOfWriters = 4;
-        options.NumberOfReaders = 4;
-        options.policy.buffer_policy = PerConnection;
-        RunnerType::shared_ptr runner(new RunnerType("dataPerConnection", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-
-#if RTT_VERSION_GTE(2,8,99)
-    // 4 writers, 4 readers, PerInputPort
-    {
-        options.NumberOfWriters = 4;
-        options.NumberOfReaders = 4;
-        options.policy.buffer_policy = PerInputPort;
-        RunnerType::shared_ptr runner(new RunnerType("dataPerInputPort", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-
-    // 4 writers, 4 readers, PerOutputPort
-    {
-        options.NumberOfWriters = 4;
-        options.NumberOfReaders = 4;
-        options.policy.buffer_policy = PerOutputPort;
-        RunnerType::shared_ptr runner(new RunnerType("dataPerOutputPort", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-#endif
-#endif
-
-#if (RTT_VERSION_MAJOR == 1) || RTT_VERSION_GTE(2,8,99)
-    // 4 writers, 4 readers, Shared
-    {
-        options.NumberOfWriters = 4;
-        options.NumberOfReaders = 4;
-        options.policy.buffer_policy = Shared;
-        RunnerType::shared_ptr runner(new RunnerType("dataShared", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-#endif
 }
 
-BOOST_AUTO_TEST_CASE( bufferConnections )
+template <>
+DataFlowPerformanceTest_<BufferPortType>::DataFlowPerformanceTest_()
 {
-    TestOptions options;
-    const PortTypes PortType = BufferPortType;
-    typedef TestRunner<SampleType,PortType> RunnerType;
-
     options.policy.type = ConnPolicy::BUFFER;
     options.policy.size = 100;
 //    options.policy.lock_policy = ConnPolicy::LOCK_FREE;
-
-#if (RTT_VERSION_MAJOR >= 2)
-    // 7 writers, 1 reader, PerConnection
-    {
-        options.NumberOfWriters = 7;
-        options.NumberOfReaders = 1;
-        options.policy.buffer_policy = PerConnection;
-        RunnerType::shared_ptr runner(new RunnerType("bufferPerConnection", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-#endif
-
-#if (RTT_VERSION_MAJOR == 1) || RTT_VERSION_GTE(2,8,99)
-    // 7 writers, 1 reader, PerInputPort
-    {
-        options.NumberOfWriters = 7;
-        options.NumberOfReaders = 1;
-        options.policy.buffer_policy = PerInputPort;
-        RunnerType::shared_ptr runner(new RunnerType("bufferPerInputPort", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-#endif
-
-#if (RTT_VERSION_MAJOR >= 2)
-    // 1 writer, 7 readers, PerConnection
-    {
-        options.NumberOfWriters = 1;
-        options.NumberOfReaders = 7;
-        options.policy.buffer_policy = PerConnection;
-        RunnerType::shared_ptr runner(new RunnerType("bufferPerConnection", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-#endif
-
-#if (RTT_VERSION_MAJOR == 1) || RTT_VERSION_GTE(2,8,99)
-    // 1 writer, 7 readers, PerOutputPort
-    {
-        options.NumberOfWriters = 1;
-        options.NumberOfReaders = 7;
-        options.policy.buffer_policy = PerOutputPort;
-        RunnerType::shared_ptr runner(new RunnerType("bufferPerOutputPort", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-#endif
-
-#if (RTT_VERSION_MAJOR >= 2)
-    // 4 writers, 4 readers, PerConnection
-    {
-        options.NumberOfWriters = 4;
-        options.NumberOfReaders = 4;
-        options.policy.buffer_policy = PerConnection;
-        RunnerType::shared_ptr runner(new RunnerType("bufferPerConnection", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-
-#if RTT_VERSION_GTE(2,8,99)
-    // 4 writers, 4 readers, PerInputPort
-    {
-        options.NumberOfWriters = 4;
-        options.NumberOfReaders = 4;
-        options.policy.buffer_policy = PerInputPort;
-        RunnerType::shared_ptr runner(new RunnerType("bufferPerInputPort", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-
-    // 4 writers, 4 readers, PerOutputPort
-    {
-        options.NumberOfWriters = 4;
-        options.NumberOfReaders = 4;
-        options.policy.buffer_policy = PerOutputPort;
-        RunnerType::shared_ptr runner(new RunnerType("bufferPerOutputPort", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-#endif
-#endif
-
-#if (RTT_VERSION_MAJOR == 1) || RTT_VERSION_GTE(2,8,99)
-    // 4 writers, 4 readers, Shared
-    {
-        options.NumberOfWriters = 4;
-        options.NumberOfReaders = 4;
-        options.policy.buffer_policy = Shared;
-        RunnerType::shared_ptr runner(new RunnerType("bufferShared", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
-#endif
 }
 
-BOOST_AUTO_TEST_CASE( emptyReads )
+struct EmptyReads;
+template <>
+DataFlowPerformanceTest_<DataPortType, EmptyReads>::DataFlowPerformanceTest_()
 {
-    TestOptions options;
-    const PortTypes PortType = DataPortType;
-    typedef TestRunner<SampleType,PortType> RunnerType;
-
+    options.policy.type = ConnPolicy::DATA;
 //    options.policy.lock_policy = ConnPolicy::LOCKED;
+
     options.WriteMode = TestOptions::NoWrite;
     options.ReadMode = TestOptions::ReadSynchronous;
+}
+
+// Registers the fixture into the 'registry'
+typedef DataFlowPerformanceTest_<DataPortType> DataFlowPerformanceTest_Data;
+BOOST_FIXTURE_TEST_SUITE( DataFlowPerformanceTest_Data_Suite, DataFlowPerformanceTest_Data )
 
 #if (RTT_VERSION_MAJOR >= 2)
-    // 7 writers, 1 reader, PerConnection
-    {
-        options.NumberOfWriters = 7;
-        options.NumberOfReaders = 1;
-        options.policy.buffer_policy = PerConnection;
-        RunnerType::shared_ptr runner(new RunnerType("emptyPerConnection", options));
+// 7 writers, 1 reader, PerConnection
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Data_PerConnection_7Writers1Reader )
+{
+    options.NumberOfWriters = 7;
+    options.NumberOfReaders = 1;
+    options.policy.buffer_policy = PerConnection;
+    runner.reset(new RunnerType(options));
+    run();
+}
+#endif
 
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
+#if (RTT_VERSION_MAJOR == 1) || RTT_VERSION_GTE(2,8,99)
+// 7 writers, 1 reader, PerInputPort
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Data_PerInputPort_7Writers1Reader )
+{
+    options.NumberOfWriters = 7;
+    options.NumberOfReaders = 1;
+    options.policy.buffer_policy = PerInputPort;
+    runner.reset(new RunnerType(options));
+    run();
+}
+#endif
 
-        runner->printStats();
-        std::cout << std::endl;
+#if (RTT_VERSION_MAJOR >= 2)
+// 1 writer, 7 readers, PerConnection
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Data_PerConnection_1Writer7Readers )
+{
+    options.NumberOfWriters = 1;
+    options.NumberOfReaders = 7;
+    options.policy.buffer_policy = PerConnection;
+    runner.reset(new RunnerType(options));
+    run();
+}
+#endif
+
+#if (RTT_VERSION_MAJOR == 1) || RTT_VERSION_GTE(2,8,99)
+// 1 writer, 7 readers, PerOutputPort
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Data_PerOutputPort_1Writer7Readers )
+{
+    options.NumberOfWriters = 1;
+    options.NumberOfReaders = 7;
+    options.policy.buffer_policy = PerOutputPort;
+    runner.reset(new RunnerType(options));
+    run();
+}
+#endif
+
+#if (RTT_VERSION_MAJOR >= 2)
+// 4 writers, 4 readers, PerConnection
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Data_PerConnection_4Writers4Readers )
+{
+    options.NumberOfWriters = 4;
+    options.NumberOfReaders = 4;
+    options.policy.buffer_policy = PerConnection;
+    runner.reset(new RunnerType(options));
+    run();
+}
+
+#if RTT_VERSION_GTE(2,8,99)
+// 4 writers, 4 readers, PerInputPort
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Data_PerInputPort_4Writers4Readers )
+{
+    options.NumberOfWriters = 4;
+    options.NumberOfReaders = 4;
+    options.policy.buffer_policy = PerInputPort;
+    runner.reset(new RunnerType(options));
+    run();
+}
+
+// 4 writers, 4 readers, PerOutputPort
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Data_PerOutputPort_4Writers4Readers )
+{
+    options.NumberOfWriters = 4;
+    options.NumberOfReaders = 4;
+    options.policy.buffer_policy = PerOutputPort;
+    runner.reset(new RunnerType(options));
+    run();
+}
+#endif
+#endif
+
+#if (RTT_VERSION_MAJOR == 1) || RTT_VERSION_GTE(2,8,99)
+// 4 writers, 4 readers, Shared
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Data_Shared_4Writers4Readers )
+{
+    options.NumberOfWriters = 4;
+    options.NumberOfReaders = 4;
+    options.policy.buffer_policy = Shared;
+    runner.reset(new RunnerType(options));
+    run();
+}
+#endif
+
+BOOST_AUTO_TEST_SUITE_END()
+
+// Registers the fixture into the 'registry'
+typedef DataFlowPerformanceTest_<BufferPortType> DataFlowPerformanceTest_Buffer;
+BOOST_FIXTURE_TEST_SUITE( DataFlowPerformanceTest_Buffer_Suite, DataFlowPerformanceTest_Buffer )
+
+#if (RTT_VERSION_MAJOR >= 2)
+// 7 writers, 1 reader, PerConnection
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Buffer_PerConnection_7Writers1Reader )
+{
+      options.NumberOfWriters = 7;
+      options.NumberOfReaders = 1;
+      options.policy.buffer_policy = PerConnection;
+      runner.reset(new RunnerType(options));
+
+      std::cout << runner->getOptions();
+      BOOST_CHECK( runner->connectAll() );
+      BOOST_CHECK( runner->run() );
+
+      runner->printStats();
+      std::cout << std::endl;
     }
 #endif
 
 #if (RTT_VERSION_MAJOR == 1) || RTT_VERSION_GTE(2,8,99)
-    // 7 writers, 1 reader, Shared
-    {
-        options.NumberOfWriters = 7;
-        options.NumberOfReaders = 1;
-        options.policy.buffer_policy = Shared;
-        RunnerType::shared_ptr runner(new RunnerType("emptyShared", options));
-
-        std::cout << runner->getOptions();
-        BOOST_CHECK( runner->connectAll() );
-        BOOST_CHECK( runner->run() );
-
-        runner->printStats();
-        std::cout << std::endl;
-    }
+// 7 writers, 1 reader, PerInputPort
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Buffer_PerInputPort_7Writers1Reader )
+{
+    options.NumberOfWriters = 7;
+    options.NumberOfReaders = 1;
+    options.policy.buffer_policy = PerInputPort;
+    runner.reset(new RunnerType(options));
+    run();
+}
 #endif
+
+#if (RTT_VERSION_MAJOR >= 2)
+// 1 writer, 7 readers, PerConnection
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Buffer_PerInputPort_1Writer7Readers )
+{
+    options.NumberOfWriters = 1;
+    options.NumberOfReaders = 7;
+    options.policy.buffer_policy = PerConnection;
+    runner.reset(new RunnerType(options));
+    run();
+}
+#endif
+
+#if (RTT_VERSION_MAJOR == 1) || RTT_VERSION_GTE(2,8,99)
+// 1 writer, 7 readers, PerOutputPort
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Buffer_PerOutputPort_1Writer7Readers )
+{
+    options.NumberOfWriters = 1;
+    options.NumberOfReaders = 7;
+    options.policy.buffer_policy = PerOutputPort;
+    runner.reset(new RunnerType(options));
+    run();
+}
+#endif
+
+#if (RTT_VERSION_MAJOR >= 2)
+// 4 writers, 4 readers, PerConnection
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Buffer_PerConnection_4Writers4Readers )
+{
+    options.NumberOfWriters = 4;
+    options.NumberOfReaders = 4;
+    options.policy.buffer_policy = PerConnection;
+    runner.reset(new RunnerType(options));
+    run();
 }
 
+#if RTT_VERSION_GTE(2,8,99)
+// 4 writers, 4 readers, PerInputPort
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Buffer_PerInputPort_4Writers4Readers )
+{
+    options.NumberOfWriters = 4;
+    options.NumberOfReaders = 4;
+    options.policy.buffer_policy = PerInputPort;
+    runner.reset(new RunnerType(options));
+    run();
+}
+
+// 4 writers, 4 readers, PerOutputPort
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Buffer_PerOutputPort_4Writers4Readers )
+{
+    options.NumberOfWriters = 4;
+    options.NumberOfReaders = 4;
+    options.policy.buffer_policy = PerOutputPort;
+    runner.reset(new RunnerType(options));
+    run();
+}
+#endif
+#endif
+
+#if (RTT_VERSION_MAJOR == 1) || RTT_VERSION_GTE(2,8,99)
+// 4 writers, 4 readers, Shared
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_Buffer_Shared_4Writers4Readers )
+{
+    options.NumberOfWriters = 4;
+    options.NumberOfReaders = 4;
+    options.policy.buffer_policy = Shared;
+    runner.reset(new RunnerType(options));
+    run();
+}
+#endif
+
+BOOST_AUTO_TEST_SUITE_END()
+
+// Registers the fixture into the 'registry'
+typedef DataFlowPerformanceTest_<DataPortType, EmptyReads> DataFlowPerformanceTest_EmptyReads;
+BOOST_FIXTURE_TEST_SUITE( DataFlowPerformanceTest_EmptyReads_Suite, DataFlowPerformanceTest_EmptyReads )
+
+#if (RTT_VERSION_MAJOR >= 2)
+// 7 writers, 1 reader, PerConnection
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_EmptyReads_PerConnection_7Writers1Reader )
+{
+    options.NumberOfWriters = 7;
+    options.NumberOfReaders = 1;
+    options.policy.buffer_policy = PerConnection;
+    runner.reset(new RunnerType(options));
+    run();
+}
+#endif
+
+#if (RTT_VERSION_MAJOR == 1) || RTT_VERSION_GTE(2,8,99)
+// 7 writers, 1 reader, Shared
+BOOST_AUTO_TEST_CASE( DataFlowPerformanceTest_EmptyReads_Shared_7Writers1Reader )
+{
+    options.NumberOfWriters = 7;
+    options.NumberOfReaders = 1;
+    options.policy.buffer_policy = Shared;
+    runner.reset(new RunnerType(options));
+    run();
+}
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/dataflow_performance_test.cpp
+++ b/tests/dataflow_performance_test.cpp
@@ -489,9 +489,9 @@ public:
     this_type &operator=(const value_type &) { throw std::runtime_error("Cannot assign CopyAndAssignmentCounted type from its value_type directly!"); }
     this_type &operator=(const this_type &other) {
         if (this == &other) return *this;
-        BOOST_ASSERT_MSG(oro_atomic_dec_and_test(&_write_guard), "Conflicting assignment detected: instance is concurrently being assigned by another thread!");
+        BOOST_REQUIRE_MESSAGE(oro_atomic_dec_and_test(&_write_guard), "Conflicting assignment detected: instance is concurrently being assigned by another thread!");
         oro_atomic_inc(&other._read_guard);
-        BOOST_ASSERT_MSG(oro_atomic_dec_and_test(&_read_guard), "Conflicting assignment detected: instance being assigned is concurrently read by another thread!");
+        BOOST_REQUIRE_MESSAGE(oro_atomic_dec_and_test(&_read_guard), "Conflicting assignment detected: instance being assigned is concurrently read by another thread!");
         static_cast<value_type &>(*this) = other;
         _counter_details = other._counter_details;
         oro_atomic_inc(&(_counter_details->assignments));

--- a/tests/dataflow_performance_test.cpp
+++ b/tests/dataflow_performance_test.cpp
@@ -463,19 +463,19 @@ public:
     typedef CopyAndAssignmentCounted<Derived> this_type;
 
     CopyAndAssignmentCounted()
-        : Derived(), _counter_details(new CopyAndAssignmentCountedDetails)
+        : Derived(), sleep_usecs_during_assignment(0), _counter_details(new CopyAndAssignmentCountedDetails)
     {
         ORO_ATOMIC_SETUP(&_write_guard, 1);
         ORO_ATOMIC_SETUP(&_read_guard, 1);
     }
     CopyAndAssignmentCounted(const value_type &value)
-        : Derived(value), _counter_details(new CopyAndAssignmentCountedDetails)
+        : Derived(value), sleep_usecs_during_assignment(0), _counter_details(new CopyAndAssignmentCountedDetails)
     {
         ORO_ATOMIC_SETUP(&_write_guard, 1);
         ORO_ATOMIC_SETUP(&_read_guard, 1);
     }
     CopyAndAssignmentCounted(const this_type &other)
-        : Derived(other), _counter_details(other._counter_details)
+        : Derived(other), sleep_usecs_during_assignment(0), _counter_details(other._counter_details)
     {
         ORO_ATOMIC_SETUP(&_write_guard, 1);
         ORO_ATOMIC_SETUP(&_read_guard, 1);
@@ -501,6 +501,8 @@ public:
         static_cast<value_type &>(*this) = other;
         _counter_details = other._counter_details;
         oro_atomic_inc(&(_counter_details->assignments));
+        if (sleep_usecs_during_assignment > 0) usleep(sleep_usecs_during_assignment);
+        if (other.sleep_usecs_during_assignment > 0) usleep(other.sleep_usecs_during_assignment);
 
         // cleanup guards
         oro_atomic_inc(&_read_guard);
@@ -517,6 +519,9 @@ public:
     }
 
     this_type detachedCopy() const { return this_type(static_cast<const value_type &>(*this)); }
+
+public:
+    int sleep_usecs_during_assignment;
 
 private:
     boost::intrusive_ptr<CopyAndAssignmentCountedDetails> _counter_details;
@@ -766,7 +771,7 @@ public:
     }
 
     ~ReaderWriterTaskContextBase() {
-        BOOST_REQUIRE(!this->inException());
+        BOOST_REQUIRE_MESSAGE(!this->inException(), exception_reason_);
     }
 
     void afterUpdateHook(bool trigger)
@@ -792,6 +797,7 @@ public:
 
     void waitUntilFinished()
     {
+        if (inException()) return;
         MutexLock lock(mutex_);
         while(number_of_cycles_ < desired_number_of_cycles_) {
             finished_.wait(mutex_);
@@ -816,6 +822,8 @@ protected:
 
     std::size_t number_of_cycles_;
     std::size_t desired_number_of_cycles_;
+
+    std::string exception_reason_;
 };
 
 template <typename T, PortTypes PortType>
@@ -854,13 +862,18 @@ public:
 
     void updateHook()
     {
-        WriteStatus fs = WriteSuccess;
-        {
-            Timer::Section section(timer);
-            fs = AdaptorType::write(output_port, sample);
+        try {
+            WriteStatus fs = WriteSuccess;
+            {
+                Timer::Section section(timer);
+                fs = AdaptorType::write(output_port, sample);
+            }
+            timer_by_status[fs].updateFrom(timer);
+            this->afterUpdateHook(/* trigger = */ true);
+        } catch(std::exception &e) {
+            exception_reason_ = e.what();
+            throw;
         }
-        timer_by_status[fs].updateFrom(timer);
-        this->afterUpdateHook(/* trigger = */ true);
     }
 
     bool breakUpdateHook()
@@ -902,17 +915,22 @@ public:
 
     void updateHook()
     {
-        FlowStatus fs = NewData;
-        while(fs == NewData) {
-            {
-                Timer::Section section(timer);
-                fs = Adaptor<SampleType,PortType>::read(input_port, sample, copy_old_data_);
+        try {
+            FlowStatus fs = NewData;
+            while(fs == NewData) {
+                {
+                    Timer::Section section(timer);
+                    fs = Adaptor<SampleType,PortType>::read(input_port, sample, copy_old_data_);
+                }
+                timer_by_status[fs].updateFrom(timer);
+                if (!read_loop_) break;
             }
-            timer_by_status[fs].updateFrom(timer);
-            if (!read_loop_) break;
-        }
 
-        this->afterUpdateHook(/* trigger = */ false);
+            this->afterUpdateHook(/* trigger = */ false);
+        } catch(std::exception &e) {
+            exception_reason_ = e.what();
+            throw;
+        }
     }
 
     bool breakUpdateHook()
@@ -942,7 +960,8 @@ struct TestOptions {
     bool KeepLastWrittenValue;
     bool ReadLoop;
     bool CopyOldData;
-
+    int SleepUsecsDuringWriteAssignment;
+    int SleepUsecsDuringReadAssignment;
     int SchedulerType;
     int ThreadPriority;
     std::bitset<16> CpuAffinity;
@@ -957,6 +976,8 @@ struct TestOptions {
           KeepLastWrittenValue(false),
           ReadLoop(false),
           CopyOldData(false),
+          SleepUsecsDuringWriteAssignment(1),
+          SleepUsecsDuringReadAssignment(10),
           SchedulerType(ORO_SCHED_RT),
           ThreadPriority(HighestPriority),
           CpuAffinity(getDefaultCpuAffinity() & std::bitset<16>(0x000f)) // run with at most 4 cores
@@ -997,6 +1018,10 @@ std::ostream &operator<<(std::ostream &os, const TestOptions &options)
     os << " * Writers:                 " << options.NumberOfWriters << std::endl;
     os << " * Readers:                 " << options.NumberOfReaders << std::endl;
     os << " * Cycles:                  " << options.NumberOfCycles << std::endl;
+    os << " *" << std::endl;
+    os << " * Sleep during write:      " << options.SleepUsecsDuringWriteAssignment << " usecs" << std::endl;
+    os << " * Sleep during read:       " << options.SleepUsecsDuringReadAssignment << " usecs" << std::endl;
+    os << " *" << std::endl;
     os << " * Scheduler:               " << schedulerTypeToString(options.SchedulerType) << std::endl;
     os << " * Priority:                " << options.ThreadPriority << std::endl;
     os << " * CPU affinity:            " << options.CpuAffinity << " (" << options.CpuAffinity.count() << " cores)" << std::endl;
@@ -1070,6 +1095,7 @@ public:
             default:
                 break;
             }
+            writer->sample.sleep_usecs_during_assignment = options.SleepUsecsDuringWriteAssignment;
         }
 
         for(std::size_t index = 0; index < options_.NumberOfReaders; ++index) {
@@ -1091,6 +1117,7 @@ public:
             default:
                 break;
             }
+            reader->sample.sleep_usecs_during_assignment = options.SleepUsecsDuringReadAssignment;
         }
     }
 

--- a/tests/dataflow_performance_test.cpp
+++ b/tests/dataflow_performance_test.cpp
@@ -1223,6 +1223,21 @@ public:
                   << "  " << std::setw(9) << total_write_timer_by_status[WriteSuccess].count()
                   << " " << std::setw(9) << total_write_timer_by_status[WriteFailure].count()
                   << std::endl;
+        std::cout << std::left
+                  << " " << std::setw(30) << "Average"
+                  << " " << std::setw(16) << ""
+                  << " " << std::setw(9)  << total_write_timer.count() / writers.size()
+                  << " " << std::setw(12) << total_write_timer.total().monotonic / writers.size()
+                  << " " << std::setw(12) << (total_write_timer.total().monotonic / total_write_timer.count()) / writers.size()
+                  << " " << std::setw(12) << total_write_timer.max().monotonic / writers.size()
+                  << " " << std::setw(12) << total_write_timer.total().cputime / writers.size()
+                  << " " << std::setw(12) << (total_write_timer.total().cputime / total_write_timer.count()) / writers.size()
+                  << " " << std::setw(12) << total_write_timer.max().cputime / writers.size()
+                  << " " << std::setw(9) << ""
+                  << " " << std::setw(9) << ""
+                  << "  " << std::setw(9) << total_write_timer_by_status[WriteSuccess].count() / writers.size()
+                  << " " << std::setw(9) << total_write_timer_by_status[WriteFailure].count() / writers.size()
+                  << std::endl;
         std::cout << std::endl;
 
         Timer total_read_timer;

--- a/tests/dataflow_performance_test.cpp
+++ b/tests/dataflow_performance_test.cpp
@@ -988,14 +988,6 @@ public:
     TestRunner(const std::string &name, const TestOptions &options)
         : options_(options)
     {
-#if RTT_VERSION_GTE(2,8,99)
-        if ((options_.policy.buffer_policy == PerInputPort || options_.policy.buffer_policy == Shared) &&
-            options_.policy.type == ConnPolicy::DATA &&
-            options_.policy.lock_policy == ConnPolicy::LOCK_FREE) {
-            options_.policy.lock_policy = ConnPolicy::LOCKED;
-            log(Warning) << "Falling back to locking policy LOCKED for a shared input data object connection!" << endlog();
-        }
-#endif
 
         for(std::size_t index = 0; index < options_.NumberOfWriters; ++index) {
             WriterPtr writer(new Writer<T,PortType>(name + "Writer", index, options_.SampleSize, options_.KeepLastWrittenValue));
@@ -1295,7 +1287,7 @@ BOOST_AUTO_TEST_CASE( dataConnections )
     typedef TestRunner<SampleType,PortType> RunnerType;
 
     options.policy.type = ConnPolicy::DATA;
-    options.policy.lock_policy = ConnPolicy::LOCK_FREE;
+//    options.policy.lock_policy = ConnPolicy::LOCK_FREE;
 
 #if (RTT_VERSION_MAJOR >= 2)
     // 7 writers, 1 reader, PerConnection
@@ -1440,7 +1432,7 @@ BOOST_AUTO_TEST_CASE( bufferConnections )
 
     options.policy.type = ConnPolicy::BUFFER;
     options.policy.size = 100;
-    options.policy.lock_policy = ConnPolicy::LOCK_FREE;
+//    options.policy.lock_policy = ConnPolicy::LOCK_FREE;
 
 #if (RTT_VERSION_MAJOR >= 2)
     // 7 writers, 1 reader, PerConnection
@@ -1583,7 +1575,7 @@ BOOST_AUTO_TEST_CASE( emptyReads )
     const PortTypes PortType = DataPortType;
     typedef TestRunner<SampleType,PortType> RunnerType;
 
-    options.policy.lock_policy = ConnPolicy::LOCKED;
+//    options.policy.lock_policy = ConnPolicy::LOCKED;
     options.WriteMode = TestOptions::NoWrite;
     options.ReadMode = TestOptions::ReadSynchronous;
 

--- a/tests/ports_test.cpp
+++ b/tests/ports_test.cpp
@@ -922,10 +922,10 @@ BOOST_AUTO_TEST_CASE(testEventPortSignalling)
     OutputPort<double> wp1("Write");
     InputPort<double>  rp1("Read");
 
-    BOOST_ASSERT(tce->configure());
-    BOOST_ASSERT(tce->isConfigured());
+    BOOST_REQUIRE(tce->configure());
+    BOOST_REQUIRE(tce->isConfigured());
 
-    BOOST_ASSERT(slsim->isActive());
+    BOOST_REQUIRE(slsim->isActive());
 
 
     tce->start();

--- a/tests/slave_test.cpp
+++ b/tests/slave_test.cpp
@@ -98,7 +98,7 @@ public:
     void callSlaveOperation()
     {
         BOOST_TEST_MESSAGE( "[ENTER] ClientComponent::callSlaveOperation()" );
-        BOOST_ASSERT(slave_operation_caller.ready());
+        BOOST_REQUIRE(slave_operation_caller.ready());
         slave_operation_caller();
         BOOST_TEST_MESSAGE( "[EXIT]  ClientComponent::callSlaveOperation()" );
     }
@@ -146,7 +146,7 @@ BOOST_FIXTURE_TEST_SUITE(  SlaveTestSuite,  SlaveActivityTest )
 BOOST_AUTO_TEST_CASE( testSlaveOperationCall )
 {
     RTT::OperationCaller<void()> callSlaveOperation = client.getOperation("callSlaveOperation");
-    BOOST_ASSERT( callSlaveOperation.ready() );
+    BOOST_REQUIRE( callSlaveOperation.ready() );
 
     // Note: master is not running!
     RTT::SendHandle<void()> handle = callSlaveOperation.send();
@@ -163,11 +163,11 @@ BOOST_AUTO_TEST_CASE( testSlaveOperationCall )
 BOOST_AUTO_TEST_CASE( testSlaveOperationCallWithCallback )
 {
     RTT::OperationCaller<void()> callSlaveOperation = client.getOperation("callSlaveOperation");
-    BOOST_ASSERT( callSlaveOperation.ready() );
+    BOOST_REQUIRE( callSlaveOperation.ready() );
 
     // connect SlaveComponent::slave_operation_caller to ClientComponent::callbackOperation()
     slave.slave_operation_caller = client.getOperation("callbackOperation");
-    BOOST_ASSERT( slave.slave_operation_caller.ready() );
+    BOOST_REQUIRE( slave.slave_operation_caller.ready() );
 
     // Note: master is not running!
     RTT::SendHandle<void()> handle = callSlaveOperation.send();


### PR DESCRIPTION
Required to fully support `PerInputPort` and `Shared` buffer policies on lock-free data connections. In order to avoid that multiple writer threads start to assign to the same storage elements pointed to by `write_ptr`, a new atomic counter has been added that allows the threads to detect the situation and start over again. Additionally, the `Get()` method has been updated to apply compare-and-swap on the `FlowStatus` stored in the buffer, so that at most one reader thread returns `NewData` for each sample.

The refactoring of the `RTT::os::SharedMutex` class is only vaguely related, but it removes the mutex that has been used to protect the state information which could be problematic and cause priority inversion issues. Non-exclusive locks on shared mutexes are used extensively in the new dataflow implementation introduced in https://github.com/orocos-toolchain/rtt/pull/114 to protect the channel pipeline from concurrent connects and disconnects, but in most cases they are only ever locked by a single thread. On the other hand a comparison with the previous implementation did not show any performance improvements using the `gnulinux` target, probably because pthread mutexes are already optimized for the case that there is no congestion.

See http://preshing.com/20120612/an-introduction-to-lock-free-programming/ for a good introduction in the topic of lock-free programming and http://preshing.com/20150316/semaphores-are-surprisingly-versatile/#a-lightweight-semaphore-with-partial-spinning for the slightly adapted idea of implementing the lock-free read-write-locks using semaphores.

Once this patch has been reviewed and tested I will port the patches to upstream RTT.

@psoetens
@smits
@snrkiwi